### PR TITLE
Fix code scanning alert no. 12: Incomplete URL substring sanitization

### DIFF
--- a/02_Front_end_Testing/ShopVehiclesAccessoriesModelS(Almaz Rakhmatullin)/Unittest/unittest_vehiclesAccessories_ModelS_module.py
+++ b/02_Front_end_Testing/ShopVehiclesAccessoriesModelS(Almaz Rakhmatullin)/Unittest/unittest_vehiclesAccessories_ModelS_module.py
@@ -799,7 +799,8 @@ class EdgeSearch(unittest.TestCase):
         print("Check Tesla page URL")
 
         try:
-            assert "https://www.tesla.com/" in driver.current_url
+            parsed_url = urllib.parse.urlparse(driver.current_url)
+            assert parsed_url.hostname == "www.tesla.com"
             print("Test result: Page URL is OK: ", driver.current_url)
         except AssertionError:
             print("Test result: Page URL is different", driver.current_url)
@@ -831,7 +832,8 @@ class EdgeSearch(unittest.TestCase):
             print("Failed to click on Vehicle Accessories")
 
         try:
-            assert "https://shop.tesla.com/category/vehicle-accessories/model-s" in driver.current_url
+            parsed_url = urllib.parse.urlparse(driver.current_url)
+            assert parsed_url.hostname == "shop.tesla.com" and parsed_url.path == "/category/vehicle-accessories/model-s"
             print("Test result: Page URL is OK: ", driver.current_url)
         except AssertionError:
             print("Test result: Page URL is different", driver.current_url)


### PR DESCRIPTION
Fixes [https://github.com/SergioUS/Tesla_testing_project/security/code-scanning/12](https://github.com/SergioUS/Tesla_testing_project/security/code-scanning/12)

To fix the problem, we need to parse the URL and check its components rather than using a substring match. Specifically, we should use the `urlparse` function from the `urllib.parse` module to extract the hostname and ensure it matches the expected value.

- Parse the URL using `urlparse`.
- Extract the hostname from the parsed URL.
- Check if the hostname matches the expected value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
