### PR TITLE
Fix code scanning alert no. 9: Incomplete URL substring sanitization

### DIFF
--- a/02_Front_end_Testing/ShopVehiclesAccessoriesModelS(Almaz Rakhmatullin)/Unittest/unittest_vehiclesAccessories_ModelS_module.py
+++ b/02_Front_end_Testing/ShopVehiclesAccessoriesModelS(Almaz Rakhmatullin)/Unittest/unittest_vehiclesAccessories_ModelS_module.py
@@ -22,6 +22,7 @@ from helpers import (loc_shop, loc_modelS, loc_good1, loc_plus_quantity,
                      loc_vehicle_acc2, amount1, amount2, loc_alert2, amount3, loc_good1_cart, loc_alert1,
                      loc_out_of_stock_text, loc_quantity, loc_good2_price)
 import HtmlTestRunner
+from urllib.parse import urlparse
 
 class ChromeSearch(unittest.TestCase):
 
@@ -423,7 +424,8 @@ class FirefoxSearch(unittest.TestCase):
         print("Check Tesla page URL")
 
         try:
-            assert "https://www.tesla.com/" in driver.current_url
+            parsed_url = urlparse(driver.current_url)
+            assert parsed_url.hostname == "www.tesla.com"
             print("Test result: Page URL is OK: ", driver.current_url)
         except AssertionError:
             print("Test result: Page URL is different", driver.current_url)


### PR DESCRIPTION
Fixes [https://github.com/SergioUS/Tesla_testing_project/security/code-scanning/9](https://github.com/SergioUS/Tesla_testing_project/security/code-scanning/9)

To fix the problem, we should parse the URL and check its hostname to ensure it matches the expected domain. This approach is more reliable than checking for a substring. We will use the `urlparse` function from the `urllib.parse` module to extract the hostname and then verify it.

- Parse the URL using `urlparse`.
- Extract the hostname from the parsed URL.
- Check if the hostname matches the expected domain.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
