### PR TITLE
Fix code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/02_Front_end_Testing/ShopLifestyle_module (Julia Delmar)/Unittest/HTML_Unittest_Tesla_Shoplifestyle_JDelmar.py
+++ b/02_Front_end_Testing/ShopLifestyle_module (Julia Delmar)/Unittest/HTML_Unittest_Tesla_Shoplifestyle_JDelmar.py
@@ -444,8 +444,10 @@ class FirefoxPositiveSearch(unittest.TestCase):
         time.sleep(1)
 
         # Verify correct URL
+        from urllib.parse import urlparse
         try:
-            assert "https://shop.tesla.com/" in driver.current_url
+            parsed_url = urlparse(driver.current_url)
+            assert parsed_url.hostname == "shop.tesla.com"
             print("URL is OK")
         except AssertionError:
             print("URL is wrong, current URL: ", driver.current_url)


### PR DESCRIPTION
Fixes [https://github.com/SergioUS/Tesla_testing_project/security/code-scanning/5](https://github.com/SergioUS/Tesla_testing_project/security/code-scanning/5)

To fix the problem, we should parse the URL and check its hostname to ensure it matches the expected domain. This can be done using the `urlparse` function from the `urllib.parse` module. Specifically, we will extract the hostname from the URL and verify that it matches "shop.tesla.com".

- Parse the URL using `urlparse`.
- Extract the hostname from the parsed URL.
- Check if the hostname matches "shop.tesla.com".
- Update the assertion to use this new check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
