### PR TITLE
Fix code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/02_Front_end_Testing/ShopLifestyle_module (Julia Delmar)/Unittest/Allure_Unittest_Tesla_Shoplifestyle_JDelmar.py
+++ b/02_Front_end_Testing/ShopLifestyle_module (Julia Delmar)/Unittest/Allure_Unittest_Tesla_Shoplifestyle_JDelmar.py
@@ -833,7 +833,9 @@ class EdgePositiveSearch(unittest.TestCase):
 
         # Verify correct URL
         try:
-            assert "https://shop.tesla.com/" in driver.current_url
+            from urllib.parse import urlparse
+            parsed_url = urlparse(driver.current_url)
+            assert parsed_url.hostname == "shop.tesla.com"
             print("URL is OK")
         except AssertionError:
             print("URL is wrong, current URL: ", driver.current_url)


### PR DESCRIPTION
Fixes [https://github.com/SergioUS/Tesla_testing_project/security/code-scanning/3](https://github.com/SergioUS/Tesla_testing_project/security/code-scanning/3)

To fix the problem, we need to parse the URL and check its hostname to ensure it matches the expected value. This can be done using the `urlparse` function from the `urllib.parse` module. Specifically, we will extract the hostname from the URL and verify that it matches "shop.tesla.com".

- Import the `urlparse` function from the `urllib.parse` module.
- Replace the substring check with a check that parses the URL and verifies the hostname.
- Ensure the functionality remains the same by maintaining the assertion and exception handling.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
